### PR TITLE
Auto Options Per Route

### DIFF
--- a/logger/log.go
+++ b/logger/log.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"errors"
+	"io/ioutil"
 	"os"
 	"runtime"
 	"strconv"
@@ -43,6 +44,9 @@ type Disk struct {
 	Path  string
 	Level string
 }
+
+// Stdiscard is a type of output that discards everything.
+type Stdiscard struct{}
 
 // Log provides capabilities to log messages both as color formatted message
 // to stdout for developers and as JSON formatted messages sent to Logstash.
@@ -176,6 +180,8 @@ func New(settings Settings) (*Log, error) {
 			}
 			overrideDefaultLevel = true
 		}
+	case Stdiscard:
+		text.Out = ioutil.Discard
 	default:
 		// We should assume text unless overriden otherwise.
 		return log, ErrLogInvalidType

--- a/logger/log.go
+++ b/logger/log.go
@@ -107,7 +107,7 @@ func New(settings Settings) (*Log, error) {
 			return &Log{}, ErrLogLogglySetup
 		}
 
-		if v.Level != "" && v.Level != "debug" {
+		if v.Level != "" {
 			level, err = logrus.ParseLevel(v.Level)
 			if err != nil {
 				return log, ErrLogInvalidLevel
@@ -139,7 +139,7 @@ func New(settings Settings) (*Log, error) {
 			text.Formatter = &logrus.JSONFormatter{}
 		}
 
-		if v.Level != "" && v.Level != "debug" {
+		if v.Level != "" {
 			level, err = logrus.ParseLevel(v.Level)
 			if err != nil {
 				return log, ErrLogInvalidLevel
@@ -153,7 +153,7 @@ func New(settings Settings) (*Log, error) {
 			text.Formatter = &logrus.JSONFormatter{}
 		}
 
-		if v.Level != "" && v.Level != "debug" {
+		if v.Level != "" {
 			level, err = logrus.ParseLevel(v.Level)
 			if err != nil {
 				return log, ErrLogInvalidLevel
@@ -173,7 +173,7 @@ func New(settings Settings) (*Log, error) {
 		text.Out = f
 		text.Formatter = &logrus.JSONFormatter{}
 
-		if v.Level != "" && v.Level != "debug" {
+		if v.Level != "" {
 			level, err = logrus.ParseLevel(v.Level)
 			if err != nil {
 				return log, err

--- a/logger/log.go
+++ b/logger/log.go
@@ -40,9 +40,8 @@ type Stdout struct {
 
 // Disk is a type of output that uses the logrus output which writes to disk.
 type Disk struct {
-	Path   string
-	Level  string
-	Format string
+	Path  string
+	Level string
 }
 
 // Log provides capabilities to log messages both as color formatted message
@@ -168,10 +167,7 @@ func New(settings Settings) (*Log, error) {
 		}
 
 		text.Out = f
-
-		if v.Format == "json" {
-			text.Formatter = &logrus.JSONFormatter{}
-		}
+		text.Formatter = &logrus.JSONFormatter{}
 
 		if v.Level != "" && v.Level != "debug" {
 			level, err = logrus.ParseLevel(v.Level)

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -16,6 +16,7 @@ type Logger interface {
 	Fatal(args ...interface{})
 	Fatalf(format string, args ...interface{})
 	Context(fields Fields) ContextualLogger
+	Flush()
 }
 
 // ContextualLogger provides the same logging methods as Logger but adds

--- a/logger/mocklogger.go
+++ b/logger/mocklogger.go
@@ -1,23 +1,58 @@
 package logger
 
 // NewLogMock returns a new mock logger
-func NewLogMock(debug, info bool) *MockLog {
-	text := new(Logger)
+func NewLogMock(settings Settings) (*MockLog, error) {
+	mockLog := &MockLog{}
 
-	return &MockLog{
-		text:  text,
-		debug: debug,
-		info:  info,
+	var level string
+
+	switch v := settings.Output.(type) {
+	case LogglySettings:
+		if level != "" {
+			level = v.Level
+		}
+	case Stderr:
+		if level != "" {
+			level = v.Level
+		}
+	case Stdout:
+		if level != "" {
+			level = v.Level
+		}
+	case Disk:
+		if level != "" {
+			level = v.Level
+		}
+	default:
+		return mockLog, ErrLogInvalidType
 	}
+
+	if level == "debug" {
+		mockLog.debug = true
+		mockLog.info = true
+	}
+	if level == "info" {
+		mockLog.debug = false
+		mockLog.info = true
+	}
+
+	mockLog.text = new(Logger)
+
+	return mockLog, nil
 }
 
 // MockLog mock object
 type MockLog struct {
 	text *Logger
+
 	// behavior flags
-	debug bool
-	info  bool
+	isLoggly bool
+	debug    bool
+	info     bool
 }
+
+// Flush inside mock logger
+func (l *MockLog) Flush() {}
 
 // Debug inside mock logger
 func (l *MockLog) Debug(args ...interface{}) {}

--- a/logger/test/mock_test.go
+++ b/logger/test/mock_test.go
@@ -6,11 +6,65 @@ import (
 	"github.com/go-gia/go-infrastructure/logger"
 )
 
-func TestLogging(t *testing.T) {
-	log := logger.NewLogMock(false, false)
+func TestStdoutLogging(t *testing.T) {
+	settings := logger.Settings{
+		Output: logger.Stdout{
+			Level: "panic",
+		},
+	}
 
-	log.Context(logger.Fields{
-		"Stuff": false,
-	}).Debug("Recording Stuff")
+	log, err := logger.New(settings)
+	if err != nil {
+		t.Fatal("Error", err)
+	}
 
+	log.Context(logger.Fields{"foo": "bar1"}).Debug("Debug")
+}
+
+func TestStderrLogging(t *testing.T) {
+	settings := logger.Settings{
+		Output: logger.Stderr{
+			Level: "panic",
+		},
+	}
+
+	log, err := logger.New(settings)
+	if err != nil {
+		t.Fatal("Error", err)
+	}
+
+	log.Context(logger.Fields{"foo": "bar2"}).Debug("Debug")
+}
+
+func TestDiskLogging(t *testing.T) {
+	settings := logger.Settings{
+		Output: logger.Disk{
+			Path:  "output.log",
+			Level: "panic",
+		},
+	}
+
+	log, err := logger.New(settings)
+	if err != nil {
+		t.Fatal("Error", err)
+	}
+
+	log.Context(logger.Fields{"foo": "bar3"}).Debug("Debug")
+}
+
+func TestLogglyLogging(t *testing.T) {
+	settings := logger.Settings{
+		Output: logger.LogglySettings{
+			Domain: "web-rat.com",
+			Token:  "gibberish",
+			Level:  "panic",
+			Tags:   []string{"version-1", "stuff", "more-stuff"},
+		},
+	}
+
+	log, err := logger.New(settings)
+	if err != nil {
+		t.Fatal("Error", err)
+	}
+	log.Context(logger.Fields{"foo": "bar4"}).Debug("Debug")
 }


### PR DESCRIPTION
This will take every incoming HandlerDefs and uniquely run through all of them taking note of all the Path/Methods and then create OPTIONS method for each unique Path.

So, if /organizations has a GET and a POST method, then hitting /organizations with OPTIONS should automatically return Allowed: "GET,POST". Same for /organizations/:orgID, etc.

*WARNING*: This also includes code from previous pull request.