### PR TITLE
OpenAPIResponses struct change and Static Directory Serving Fix

### DIFF
--- a/webserver/handlerdef.go
+++ b/webserver/handlerdef.go
@@ -31,8 +31,9 @@ type (
 		// The maximum time this HandlerFunc should take to process. This information is useful for performance testing.
 		DurationExpectation string `json:"duration,omitempty"`
 		// OpenAPIParams is a list of parameters which the handler can accept
-		OpenAPIParams    []openapi.Parameter `json:"openAPIParams,omitempty"`
-		OpenAPIResponses openapi.Responses   `json:"openAPIResponses,omitempty"`
+		OpenAPIParams []openapi.Parameter `json:"openAPIParams,omitempty"`
+		// OpenAPIResponses is a map of http error codes as strings with their Response
+		OpenAPIResponses map[string]openapi.Response `json:"openAPIResponses,omitempty"`
 		// An optional structure containing search/query parameters for the
 		// HandlerFunc.
 		Params        interface{} `json:"params,omitempty"`

--- a/webserver/handlerdef.go
+++ b/webserver/handlerdef.go
@@ -31,8 +31,7 @@ type (
 		// The maximum time this HandlerFunc should take to process. This information is useful for performance testing.
 		DurationExpectation string `json:"duration,omitempty"`
 		// OpenAPIParams is a list of parameters which the handler can accept
-		OpenAPIParams []openapi.Parameter `json:"openAPIParams,omitempty"`
-		// OpenAPIResponses is a map of http error codes as strings with their Response
+		OpenAPIParams    []openapi.Parameter         `json:"openAPIParams,omitempty"`
 		OpenAPIResponses map[string]openapi.Response `json:"openAPIResponses,omitempty"`
 		// An optional structure containing search/query parameters for the
 		// HandlerFunc.

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -12,9 +12,9 @@ import (
 	"sync"
 	"time"
 
-	"bitbucket.org/powerchord/platform/vendor/github.com/go-gia/go-infrastructure/logger"
-	"bitbucket.org/powerchord/platform/vendor/github.com/go-gia/go-infrastructure/webserver/context"
-	"bitbucket.org/powerchord/platform/vendor/github.com/go-gia/go-infrastructure/webserver/render"
+	"github.com/go-gia/go-infrastructure/logger"
+	"github.com/go-gia/go-infrastructure/webserver/context"
+	"github.com/go-gia/go-infrastructure/webserver/render"
 	"github.com/gorilla/mux"
 )
 


### PR DESCRIPTION
The `responses` section of the OpenAPI specification requires that the responses be in the form of a map/hash with the status code of the response as the key. This pull request will change the type of `OpenAPIResponses` to accommodate.